### PR TITLE
Add noteblocks and jukeboxes to proximity hidden blocks

### DIFF
--- a/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
+++ b/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
@@ -459,7 +459,7 @@ public class OrebfuscatorConfig {
         setBlockValues(ObfuscateBlocks, getIntList("Lists.ObfuscateBlocks", Arrays.asList(new Integer[]{14, 15, 16, 21, 54, 56, 73, 74, 129, 130})), false);
         setBlockValues(NetherObfuscateBlocks, getIntList("Lists.NetherObfuscateBlocks", Arrays.asList(new Integer[]{87, 153})), false);
         setBlockValues(DarknessBlocks, getIntList("Lists.DarknessBlocks", Arrays.asList(new Integer[]{52, 54})));
-        setBlockValues(ProximityHiderBlocks, getIntList("Lists.ProximityHiderBlocks", Arrays.asList(new Integer[]{23, 52, 54, 56, 58, 61, 62, 116, 129, 130, 145, 146})));
+        setBlockValues(ProximityHiderBlocks, getIntList("Lists.ProximityHiderBlocks", Arrays.asList(new Integer[]{23, 25, 52, 54, 56, 58, 61, 62, 84, 116, 129, 130, 145, 146})));
 
         // Disable worlds
         DisabledWorlds = getStringList("Lists.DisabledWorlds", DisabledWorlds);


### PR DESCRIPTION
Right now, Orebfuscator doesn't hide noteblocks and jukeboxes by default. This gives a huge advantage to players who cheat with x-ray mods and block scanners.

It looks like the block lists in OrebfuscatorConfig.java are just used to generate the initial config, so you'll also have to add these values (25, and 84) to the config files on the relevant servers.

**Edit: I'd also sent a message to modmail, and it looks like the config change on the game servers has been applied and will be live after the next restart.**
